### PR TITLE
chore: use legacy peer-deps mode on npm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+legacy-peer-deps=true


### PR DESCRIPTION
...because Node packages aren't there yet...